### PR TITLE
Implement basic coffee recipe guide

### DIFF
--- a/app/src/main/java/com/example/pour_over_coffee/MainActivity.kt
+++ b/app/src/main/java/com/example/pour_over_coffee/MainActivity.kt
@@ -7,11 +7,13 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.example.pour_over_coffee.ui.theme.PourovercoffeeTheme
+
+import com.example.pour_over_coffee.sampleRecipe
+import com.example.pour_over_coffee.RecipeScreen
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -20,8 +22,8 @@ class MainActivity : ComponentActivity() {
         setContent {
             PourovercoffeeTheme {
                 Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Greeting(
-                        name = "Android",
+                    RecipeScreen(
+                        recipe = sampleRecipe,
                         modifier = Modifier.padding(innerPadding)
                     )
                 }
@@ -30,18 +32,10 @@ class MainActivity : ComponentActivity() {
     }
 }
 
-@Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
-}
-
 @Preview(showBackground = true)
 @Composable
-fun GreetingPreview() {
+fun RecipePreview() {
     PourovercoffeeTheme {
-        Greeting("Android")
+        RecipeScreen(recipe = sampleRecipe)
     }
 }

--- a/app/src/main/java/com/example/pour_over_coffee/Recipe.kt
+++ b/app/src/main/java/com/example/pour_over_coffee/Recipe.kt
@@ -1,0 +1,23 @@
+package com.example.pour_over_coffee
+
+data class PourOverStep(
+    val waterGrams: Int,
+    val waitSeconds: Int
+)
+
+data class PourOverRecipe(
+    val beansGrams: Int,
+    val totalWater: Int,
+    val steps: List<PourOverStep>
+)
+
+val sampleRecipe = PourOverRecipe(
+    beansGrams = 20,
+    totalWater = 300,
+    steps = listOf(
+        PourOverStep(waterGrams = 60, waitSeconds = 30),
+        PourOverStep(waterGrams = 70, waitSeconds = 30),
+        PourOverStep(waterGrams = 90, waitSeconds = 30),
+        PourOverStep(waterGrams = 80, waitSeconds = 0)
+    )
+)

--- a/app/src/main/java/com/example/pour_over_coffee/RecipeScreen.kt
+++ b/app/src/main/java/com/example/pour_over_coffee/RecipeScreen.kt
@@ -1,0 +1,38 @@
+package com.example.pour_over_coffee
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun RecipeScreen(recipe: PourOverRecipe, modifier: Modifier = Modifier) {
+    Column(modifier = modifier.padding(16.dp)) {
+        Text(
+            text = "Beans: ${recipe.beansGrams}g",
+            style = MaterialTheme.typography.headlineSmall
+        )
+        Text(
+            text = "Total Water: ${recipe.totalWater}g",
+            style = MaterialTheme.typography.bodyLarge,
+            modifier = Modifier.padding(bottom = 16.dp)
+        )
+        LazyColumn {
+            itemsIndexed(recipe.steps) { index, step ->
+                Card(modifier = Modifier.padding(vertical = 4.dp)) {
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        Text(text = "Step ${index + 1}")
+                        Text(text = "Add ${step.waterGrams}g of water")
+                        Text(text = "Wait ${step.waitSeconds} seconds")
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add data model for pour-over recipe
- display recipe steps with `RecipeScreen`
- show `RecipeScreen` from `MainActivity`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684995cbfeb48320b808a3df2a345a5b