### PR TITLE
Add timer for pour-over steps

### DIFF
--- a/app/src/main/java/com/example/pour_over_coffee/RecipeScreen.kt
+++ b/app/src/main/java/com/example/pour_over_coffee/RecipeScreen.kt
@@ -6,20 +6,30 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
 
 @Composable
 fun RecipeScreen(recipe: PourOverRecipe, modifier: Modifier = Modifier) {
+    var currentStep by remember { mutableStateOf(0) }
+    val doneSteps = remember {
+        mutableStateListOf<Boolean>().apply {
+            repeat(recipe.steps.size) { add(false) }
+        }
+    }
+
     Column(modifier = modifier.padding(16.dp)) {
         Text(
             text = "Beans: ${recipe.beansGrams}g",
@@ -32,40 +42,61 @@ fun RecipeScreen(recipe: PourOverRecipe, modifier: Modifier = Modifier) {
         )
         LazyColumn {
             itemsIndexed(recipe.steps) { index, step ->
-                StepItem(step = step, index = index)
+                StepItem(
+                    step = step,
+                    index = index,
+                    enabled = index == currentStep,
+                    done = doneSteps[index]
+                ) {
+                    doneSteps[index] = true
+                    if (currentStep == index && currentStep < recipe.steps.size - 1) {
+                        currentStep++
+                    }
+                }
             }
         }
     }
 }
 
 @Composable
-private fun StepItem(step: PourOverStep, index: Int) {
+private fun StepItem(
+    step: PourOverStep,
+    index: Int,
+    enabled: Boolean,
+    done: Boolean,
+    onDone: () -> Unit
+) {
     var remaining by remember { mutableStateOf(step.waitSeconds) }
     var running by remember { mutableStateOf(false) }
 
     LaunchedEffect(running) {
-        if (running) {
+        if (running && !done) {
             remaining = step.waitSeconds
             while (remaining > 0) {
                 delay(1000)
                 remaining--
             }
             running = false
+            onDone()
         }
     }
 
     Card(
         modifier = Modifier
             .padding(vertical = 4.dp)
-            .clickable { running = true }
+            .clickable(enabled = enabled && !running && !done) { running = true }
+            ,
+        colors = CardDefaults.cardColors(
+            containerColor = if (done) Color(0xFFA5D6A7) else MaterialTheme.colorScheme.surface
+        )
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
             Text(text = "Step ${index + 1}")
             Text(text = "Add ${step.waterGrams}g of water")
-            val waitText = if (running) {
-                "Time left: ${remaining} seconds"
-            } else {
-                "Wait ${step.waitSeconds} seconds"
+            val waitText = when {
+                done -> "done"
+                running -> "Time left: ${remaining} seconds"
+                else -> "Wait ${step.waitSeconds} seconds"
             }
             Text(text = waitText)
         }

--- a/app/src/main/java/com/example/pour_over_coffee/RecipeScreen.kt
+++ b/app/src/main/java/com/example/pour_over_coffee/RecipeScreen.kt
@@ -1,5 +1,6 @@
 package com.example.pour_over_coffee
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -8,8 +9,14 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
 
 @Composable
 fun RecipeScreen(recipe: PourOverRecipe, modifier: Modifier = Modifier) {
@@ -25,14 +32,42 @@ fun RecipeScreen(recipe: PourOverRecipe, modifier: Modifier = Modifier) {
         )
         LazyColumn {
             itemsIndexed(recipe.steps) { index, step ->
-                Card(modifier = Modifier.padding(vertical = 4.dp)) {
-                    Column(modifier = Modifier.padding(16.dp)) {
-                        Text(text = "Step ${index + 1}")
-                        Text(text = "Add ${step.waterGrams}g of water")
-                        Text(text = "Wait ${step.waitSeconds} seconds")
-                    }
-                }
+                StepItem(step = step, index = index)
             }
+        }
+    }
+}
+
+@Composable
+private fun StepItem(step: PourOverStep, index: Int) {
+    var remaining by remember { mutableStateOf(step.waitSeconds) }
+    var running by remember { mutableStateOf(false) }
+
+    LaunchedEffect(running) {
+        if (running) {
+            remaining = step.waitSeconds
+            while (remaining > 0) {
+                delay(1000)
+                remaining--
+            }
+            running = false
+        }
+    }
+
+    Card(
+        modifier = Modifier
+            .padding(vertical = 4.dp)
+            .clickable { running = true }
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(text = "Step ${index + 1}")
+            Text(text = "Add ${step.waterGrams}g of water")
+            val waitText = if (running) {
+                "Time left: ${remaining} seconds"
+            } else {
+                "Wait ${step.waitSeconds} seconds"
+            }
+            Text(text = waitText)
         }
     }
 }


### PR DESCRIPTION
## Summary
- add countdown timer to each pour-over step

## Testing
- `./gradlew test --console=plain` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684996f244b88320beb4a893df8a7eae